### PR TITLE
Fix organisation url for "join us"

### DIFF
--- a/components/page.tsx
+++ b/components/page.tsx
@@ -310,7 +310,7 @@ function PageContent() {
     {
       name: "join us",
       title: "contribute to our open source software",
-      url: "https://github.com/anti-work",
+      url: "https://github.com/antiwork",
       icon: <Users size={28} className="text-current" />,
     },
   ];


### PR DESCRIPTION
Fix from ``https://github.com/anti-work`` to ``https://github.com/antiwork``.