### PR TITLE
Replaced flexile_devin_github_pat with GITHUB_TOKEN to fix rate limits

### DIFF
--- a/app/api/bounties/route.ts
+++ b/app/api/bounties/route.ts
@@ -48,8 +48,8 @@ async function fetchIssuesForRepo(
     "User-Agent": "Antiwork-Bounties-App",
   };
 
-  if (process.env.flexile_devin_github_pat) {
-    headers.Authorization = `token ${process.env.flexile_devin_github_pat}`;
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `token ${process.env.GITHUB_TOKEN}`;
   }
 
   const response = await fetch(url, {


### PR DESCRIPTION
## Problem
The GitHub token environment variable was named `flexile_devin_github_pat` which wasn't being recognized, causing the app to make unauthenticated requests to the GitHub API. This limited us to 60 requests per hour and was causing rate limit issues.

## Solution
Changed the environment variable name to GITHUB_TOKEN so the token is properly recognized and used for authentication

## Impact
- Increases API rate limit from 60 to 5,000 requests per hour
- Prevents rate limiting errors when fetching bounty issues
- Uses standard environment variable naming convention