### PR TITLE
fix: Responsive Logo Size in mobile for bounties

### DIFF
--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -111,8 +111,12 @@ function BountiesContent() {
         setLogoSize(100);
       } else if (window.innerWidth >= 1024) {
         setLogoSize(80);
-      } else if (window.innerWidth >= 640) {
+      } else if (window.innerWidth >= 590) {
         setLogoSize(60);
+      } else if (window.innerWidth >= 470) {
+        setLogoSize(48);
+      } else {
+        setLogoSize(36);
       }
     };
 


### PR DESCRIPTION
before
<img width="456" height="818" alt="Screenshot 2025-08-08 at 01 37 27" src="https://github.com/user-attachments/assets/cff0ba1d-8ea0-4c00-b4f7-7b445335908e" />

after
<img width="523" height="641" alt="Screenshot 2025-08-08 at 01 42 01" src="https://github.com/user-attachments/assets/cead8118-adfb-4fca-83ff-d3dc2f6b942c" />
