### PR TITLE
feat: add revalidate to cache to prevent gh rate limit

### DIFF
--- a/app/api/bounties/route.ts
+++ b/app/api/bounties/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const revalidate = 300; // 5 minutes
+
 interface GitHubIssue {
   id: number;
   number: number;
@@ -53,6 +55,7 @@ async function fetchIssuesForRepo(repo: string): Promise<GitHubIssue[]> {
 
   const response = await fetch(url, {
     headers,
+    next: { revalidate: Math.floor(CACHE_TTL_MS / 1000) },
   });
 
   if (!response.ok) {


### PR DESCRIPTION
- Currently we are relying on github token + gh api to make sure we don't go beyond the rate limit
- This changes to cache the response for 5 minutes and then serve it to all users