### PR TITLE
fix(bounites/page.tsx): make external link icon clickable on bounties…

### DIFF
--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -427,7 +427,9 @@ function BountiesContent() {
                             >
                               {getBountyAmount(issue.labels)}
                             </span>
-                            <ExternalLink size={16} />
+                            <a href={issue.html_url}>
+                              <ExternalLink size={16} />
+                            </a>
                           </div>
                         </div>
                       </CardHeader>


### PR DESCRIPTION
This PR addresses #80 

# Fix: Make External Link Icon Clickable on Bounties Page

@devsargam can you merge this