### PR TITLE
fix: make external link work on /bounties

### DIFF
--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -427,7 +427,15 @@ function BountiesContent() {
                             >
                               {getBountyAmount(issue.labels)}
                             </span>
-                            <ExternalLink size={16} />
+                            <a
+                              href={issue.html_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="hover:opacity-75"
+                              style={{ color: textColor }}
+                            >
+                              <ExternalLink size={16} />
+                            </a>
                           </div>
                         </div>
                       </CardHeader>


### PR DESCRIPTION
Fix external link icon click functionality on /bounties page, wrapped icon in anchor tag to make it clickable