### PR TITLE
feat: make bounties page dynamic to fetch all repositories

### DIFF
--- a/app/api/bounties/route.ts
+++ b/app/api/bounties/route.ts
@@ -26,21 +26,97 @@ interface ProcessedIssue extends GitHubIssue {
 }
 
 const BOUNTY_LABELS = ["$100", "$250", "$1K", "$2.5K", "$5K", "$10K", "$20K"];
-const REPOSITORIES = [
-  "antiwork/gumroad",
-  "antiwork/flexile",
-  "antiwork/helper",
-  "antiwork/gumboard",
-  "antiwork/smallbets",
-];
 
-const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes for issues
+const REPO_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour for repositories
+
 let cachedData: {
   issues: ProcessedIssue[];
+  repositories: string[];
   total: number;
   errors?: string[];
 } | null = null;
 let cacheTimestamp: number = 0;
+
+let cachedRepos: string[] | null = null;
+let repoCacheTimestamp: number = 0;
+
+async function fetchAllRepos(): Promise<string[]> {
+  const now = Date.now();
+  if (cachedRepos && now - repoCacheTimestamp < REPO_CACHE_TTL_MS) {
+    console.log("Serving cached repositories");
+    return cachedRepos;
+  }
+
+  console.log("Fetching all repositories from antiwork organization");
+  const allRepos: string[] = [];
+  let page = 1;
+  const perPage = 100;
+  const org = "antiwork";
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "Antiwork-Bounties-App",
+  };
+
+  if (process.env.GH_TOKEN) {
+    headers.Authorization = `token ${process.env.GH_TOKEN}`;
+  }
+
+  try {
+    while (true) {
+      const url = `https://api.github.com/orgs/${org}/repos?per_page=${perPage}&page=${page}&type=all`;
+      const response = await fetch(url, {
+        headers,
+        next: { revalidate: Math.floor(REPO_CACHE_TTL_MS / 1000) },
+      });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          console.warn(`Organization ${org} not found`);
+          break;
+        }
+        if (response.status === 403 || response.status === 429) {
+          throw new Error(`GitHub API rate limit exceeded while fetching repos`);
+        }
+        throw new Error(
+          `GitHub API error while fetching repos: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const repos: Array<{ full_name: string }> = await response.json();
+
+      if (repos.length === 0) {
+        break;
+      }
+
+      repos.forEach((repo) => {
+        allRepos.push(repo.full_name);
+      });
+
+      // Check if there are more pages
+      const linkHeader = response.headers.get("link");
+      if (!linkHeader || !linkHeader.includes('rel="next"')) {
+        break;
+      }
+
+      page++;
+    }
+
+    cachedRepos = allRepos;
+    repoCacheTimestamp = now;
+    console.log(`Fetched ${allRepos.length} repositories`);
+    return allRepos;
+  } catch (error) {
+    console.error("Error fetching repositories:", error);
+    // Return cached repos if available, otherwise throw
+    if (cachedRepos) {
+      console.log("Using cached repositories due to error");
+      return cachedRepos;
+    }
+    throw error;
+  }
+}
 
 async function fetchIssuesForRepo(repo: string): Promise<GitHubIssue[]> {
   const url = `https://api.github.com/repos/${repo}/issues?state=open&per_page=100`;
@@ -85,8 +161,24 @@ export async function GET() {
     console.log("Fetching fresh bounties data from GitHub API");
     const errors: string[] = [];
 
+    // Fetch all repositories dynamically
+    let repositories: string[] = [];
+    try {
+      repositories = await fetchAllRepos();
+      if (repositories.length === 0) {
+        errors.push("No repositories found in organization");
+      }
+    } catch (error) {
+      console.error("Error fetching repositories:", error);
+      errors.push(
+        `Failed to fetch repositories: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      // Fallback to empty array - will result in no issues but won't crash
+      repositories = [];
+    }
+
     const repoIssueResults = await Promise.all(
-      REPOSITORIES.map(async (repo) => {
+      repositories.map(async (repo) => {
         try {
           const issues = await fetchIssuesForRepo(repo);
           return { repo, issues };
@@ -136,6 +228,7 @@ export async function GET() {
 
     const response = {
       issues: uniqueIssues,
+      repositories: repositories,
       total: uniqueIssues.length,
       errors: errors.length > 0 ? errors : undefined,
     };

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -53,6 +53,7 @@ function BountiesContent() {
     loading: true,
     error: null,
   });
+  const [repositories, setRepositories] = useState<string[]>([]);
   const [amountFilter, setAmountFilter] = useState("All");
   const [repoFilter, setRepoFilter] = useState("All");
   const [sortBy, setSortBy] = useState("amount");
@@ -139,13 +140,25 @@ function BountiesContent() {
         throw new Error(data.error || "Failed to fetch bounties");
       }
 
-      setBountiesData({ issues: data.issues, loading: false, error: null });
+      // Extract repositories from API response or use unique repos from issues as fallback
+      const reposFromApi = data.repositories || [];
+      const uniqueReposFromIssues = Array.from(
+        new Set(data.issues?.map((issue: GitHubIssue) => issue.repository) || [])
+      );
+      const allRepos = reposFromApi.length > 0 ? reposFromApi : uniqueReposFromIssues;
+      
+      // Sort repositories alphabetically
+      allRepos.sort();
+
+      setRepositories(allRepos);
+      setBountiesData({ issues: data.issues || [], loading: false, error: null });
     } catch (error) {
       setBountiesData({
         issues: [],
         loading: false,
         error: error instanceof Error ? error.message : "Something went wrong",
       });
+      setRepositories([]);
     }
   };
 
@@ -246,43 +259,11 @@ function BountiesContent() {
         >
           Open source bounties from{" "}
           <a
-            href="https://github.com/antiwork/gumroad"
+            href="https://github.com/antiwork"
             className="underline hover:no-underline"
             style={{ color: textColor }}
           >
-            Gumroad
-          </a>
-          ,{" "}
-          <a
-            href="https://github.com/antiwork/flexile"
-            className="underline hover:no-underline"
-            style={{ color: textColor }}
-          >
-            Flexile
-          </a>
-          ,{" "}
-          <a
-            href="https://github.com/antiwork/helper"
-            className="underline hover:no-underline"
-            style={{ color: textColor }}
-          >
-            Helper
-          </a>
-          ,{" "}
-          <a
-            href="https://github.com/antiwork/gumboard"
-            className="underline hover:no-underline"
-            style={{ color: textColor }}
-          >
-            Gumboard
-          </a>
-          , and{" "}
-          <a
-            href="https://github.com/antiwork/smallbets"
-            className="underline hover:no-underline"
-            style={{ color: textColor }}
-          >
-            Small Bets
+            Antiwork repositories
           </a>
           .
         </p>
@@ -340,11 +321,11 @@ function BountiesContent() {
               }}
             >
               <option value="All">All repositories</option>
-              <option value="antiwork/gumroad">antiwork/gumroad</option>
-              <option value="antiwork/flexile">antiwork/flexile</option>
-              <option value="antiwork/helper">antiwork/helper</option>
-              <option value="antiwork/gumboard">antiwork/gumboard</option>
-              <option value="antiwork/smallbets">antiwork/smallbets</option>
+              {repositories.map((repo) => (
+                <option key={repo} value={repo}>
+                  {repo}
+                </option>
+              ))}
             </select>
           </div>
 


### PR DESCRIPTION
## Before
![before](https://github.com/user-attachments/assets/feb41d0f-4078-4cf6-9d75-002b7dd8c1e2)

## After
![after](https://github.com/user-attachments/assets/d95c0206-0ed6-42bb-9ee1-30f7992af638)
 
## AI Disclosure

**AI Disclosure**
- Model: Claude 3.5 Sonnet via Cursor
- Used for: 
  - Codebase exploration and understanding existing patterns
- Code was manually reviewed and modified by me

---

**Confirmation**: I have watched the [PR live streaming videos](https://youtu.be/JxFATKJmHcs)


### Backend (`app/api/bounties/route.ts`)
-  Added `fetchAllRepos()` function that fetches all repos from `antiwork` organization via GitHub API
-  Implemented pagination support to handle organizations with many repositories
-  Added separate caching for repositories (1 hour TTL) vs issues (5 minutes TTL)
-  Updated API response to include `repositories` array
-  Removed hardcoded `REPOSITORIES` constant
-  Added error handling with fallback to cached repos

### Frontend (`app/bounties/page.tsx`)
-  Added `repositories` state to store dynamic repository list
-  Updated `fetchBounties()` to extract repositories from API response
-  Made repository filter dropdown dynamic using `repositories.map()`
-  Updated description text to generic "Antiwork repositories" link
-  Added fallback to extract unique repos from issues if API doesn't return repos list
