### PR TITLE
Rename balance sheet slide to "Cash on Hand"

### DIFF
--- a/app/2026/slides/balance-sheet.tsx
+++ b/app/2026/slides/balance-sheet.tsx
@@ -33,7 +33,7 @@ export default function SlideBalanceSheet() {
     <div className="flex h-full w-full flex-col">
       <div className="mt-8 flex h-16 shrink-0 flex-col items-center justify-center md:mt-12 md:h-24">
         <h1 className="text-2xl font-bold text-gray-900 md:text-4xl lg:text-5xl dark:text-white">
-          Balance Sheet
+          Cash on Hand
         </h1>
       </div>
 


### PR DESCRIPTION
## Summary
- Changes the balance sheet slide title from "Balance Sheet" to "Cash on Hand"

## Test plan
- [ ] Verify slide title displays "Cash on Hand"

🤖 Generated with [Claude Code](https://claude.com/claude-code)