### PR TITLE
Homepage: clarify enterprise price ($50k–$250k) + fix call-list bullets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -522,7 +522,7 @@ export default function Home() {
         <p className="mt-3.5 text-[18px] text-fg">
           90 minutes, 1:1, with the team that built and runs Gumclaw.
         </p>
-        <ul className="mt-4 pl-5 text-muted-2">
+        <ul className="mt-4 list-disc space-y-2 pl-5 text-muted-2 marker:text-[#ec4899]">
           <li>
             A teardown of where an agent can take work off your team first.
           </li>
@@ -617,7 +617,7 @@ export default function Home() {
             </p>
           </div>
           <p className="m-0 whitespace-nowrap text-[15px] font-bold text-fg">
-            From $50,000
+            $50,000–$250,000
           </p>
         </div>
 


### PR DESCRIPTION
Two small homepage polish changes per Sahil:

- **Enterprise/build rung price**: `From $50,000` → **`$50,000–$250,000`**. A range reads clearer than an open-ended floor and anchors the top end.
- **'The call' deliverables list**: the `<ul>` was `pl-5`-indented but had no list markers, so it looked weirdly indented. Added `list-disc` + `space-y-2` with pink (`marker:text-[#ec4899]`) bullets to match the brand accent. Verified via local screenshot.

Co-authored-by: Sahil Lavingia <sahil.lavingia@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/antiwork/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783540573&installation_id=134400930&pr_number=135&repository=antiwork%2Fantiwork&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fantiwork%2Fpull%2F135&signature=ee0d8c92cb80194c49e94703546c80f691952f87a690a4e97fc7ec87825a04a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and Tailwind class tweaks on the marketing homepage only; no APIs, auth, or business logic.
> 
> **Overview**
> **Homepage polish** in `app/page.tsx` only.
> 
> The **“Build it with us”** tier now shows **`$50,000–$250,000`** instead of **“From $50,000”**, so the implementation engagement is framed as a bounded range rather than an open-ended floor.
> 
> In **“The call”**, the deliverables `<ul>` gains **`list-disc`**, **`space-y-2`**, and **pink markers** (`marker:text-[#ec4899]`) so indented items read as a real bullet list aligned with the site accent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71236132eaf6787158856e3888b570f14c2cf77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->