### PR TITLE
Homepage ladder: book-a-call pill in the rung + drop bracketing copy

### DIFF
--- a/app/components/BookCTA.tsx
+++ b/app/components/BookCTA.tsx
@@ -9,7 +9,7 @@ import {
   type Variant,
 } from "@/app/lib/experiment";
 
-type Placement = "hero" | "mid" | "offer" | "sticky";
+type Placement = "hero" | "mid" | "offer" | "sticky" | "rung";
 
 const SIZES: Record<
   Placement,
@@ -19,9 +19,16 @@ const SIZES: Record<
   mid: { padding: "12px 20px", fontSize: 15, borderRadius: 999 },
   offer: { padding: "14px 24px", fontSize: 17, borderRadius: 999 },
   sticky: { padding: "12px 22px", fontSize: 15, borderRadius: 999 },
+  rung: { padding: "7px 16px", fontSize: 13, borderRadius: 999 },
 };
 
-export function BookCTA({ placement }: { placement: Placement }) {
+export function BookCTA({
+  placement,
+  label,
+}: {
+  placement: Placement;
+  label?: string;
+}) {
   // Assign after mount to avoid a hydration mismatch; render the control
   // label on the server and first paint, then swap to the visitor's variant.
   const [variant, setVariant] = useState<Variant>("control");
@@ -45,7 +52,7 @@ export function BookCTA({ placement }: { placement: Placement }) {
         fontSize: size.fontSize,
       }}
     >
-      {CTA_LABELS[variant]}
+      {label ?? CTA_LABELS[variant]}
     </a>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -552,12 +552,6 @@ export default function Home() {
         Other ways to work with us
       </p>
 
-      <p className="mt-4 text-muted">
-        The call is the front door. Depending on where you are, there&apos;s a
-        lighter way in and a heavier way forward — same playbook, different
-        depth.
-      </p>
-
       <div className="mt-6 flex flex-col gap-3">
         {/* Rung 0 — free */}
         <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-[12px] border border-card-border bg-[color:var(--card)] bg-card px-5 py-4 shadow-card-sm">
@@ -586,7 +580,7 @@ export default function Home() {
         </div>
 
         {/* Rung 2 — the call (you are here) */}
-        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-[12px] border border-[#ec4899] bg-[color:var(--card)] bg-card px-5 py-4 shadow-card-sm">
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-[12px] border border-[#ec4899] bg-[color:var(--card)] bg-card px-5 py-4 shadow-card-sm">
           <div className="flex-[1_1_260px]">
             <div className="flex items-center gap-2">
               <p className="m-0 text-[15px] font-bold text-fg">
@@ -597,11 +591,11 @@ export default function Home() {
               </span>
             </div>
             <p className="mt-1 text-[13px] text-muted">
-              90 minutes, 1:1, with the team that built and runs Gumclaw. Credit
-              applies toward what comes next.
+              90 minutes, 1:1, with the team that built and runs Gumclaw.
+              $10,000 — credit applies toward what comes next.
             </p>
           </div>
-          <p className="m-0 text-[15px] font-bold text-[#be185d]">$10,000</p>
+          <BookCTA placement="rung" label="Book a call →" />
         </div>
 
         {/* Rung 3 — implementation */}
@@ -633,12 +627,6 @@ export default function Home() {
           <p className="m-0 text-[15px] font-bold text-fg">Let&apos;s talk</p>
         </div>
       </div>
-
-      <p className="mt-4 text-[13px] text-muted">
-        Pricing flexes with company size and where you are in the world — a
-        five-person bootstrapped shop and a hundred-person VC-backed company
-        don&apos;t pay the same for the same room. Ask.
-      </p>
 
       <Faq />
 


### PR DESCRIPTION
Per Sahil — make the ladder stand on its own and put booking right in the rung, Gumroad-style.

- **Book-a-call pill in the rung**: the teardown-call rung now has a subtle pink `Book a call →` pill on the right instead of a bare $10,000 price. Reuses `BookCTA` so the checkout URL + A/B click tracking stay wired; the $10k figure moves into the rung description so it's not lost. Added a small `rung` size + optional `label` override to `BookCTA`.
- **Dropped the copy above and below the ladder**: removed the 'The call is the front door…' intro paragraph and the 'Pricing flexes…' note, so the five rungs stand clean.

Verified via local screenshot — pill is subtle, centered, consistent with the other rungs. The hero/offer $10k CTA above is unchanged.

Co-authored-by: Sahil Lavingia <sahil.lavingia@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/antiwork/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783541210&installation_id=134400930&pr_number=136&repository=antiwork%2Fantiwork&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fantiwork%2Fpull%2F136&signature=9fda434781260d17dfeae23eed7dea6977bd9983741dc51298e9ff987a86e575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage marketing copy and CTA placement only; reuses existing checkout URL and analytics with no auth or backend changes.
> 
> **Overview**
> The **“Other ways to work with us”** ladder is tightened so the five rungs read on their own: the intro (“The call is the front door…”) and the footnote about flexible pricing are removed.
> 
> On the highlighted **teardown call** rung, the right side no longer shows only **$10,000**; it now uses **`BookCTA`** with a smaller **`rung`** style and fixed label **“Book a call →”**, so checkout and existing **`cta_view` / `cta_click`** tracking (including A/B variants) still apply. The **$10,000** amount moves into the rung body copy with the credit note. **`BookCTA`** gains an optional **`label`** override when the experiment labels shouldn’t show.
> 
> Hero, offer, and sticky CTAs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8237c8b27e6b6c1116e4844b6c89e4d7d7bc3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->