### PR TITLE
Remove standalone 'The call' offer block

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -515,40 +515,7 @@ export default function Home() {
         it from us.
       </p>
 
-      <section className="mt-7 rounded-[14px] border border-card-border bg-[color:var(--card)] bg-card p-7 shadow-card">
-        <p className="m-0 text-[12px] uppercase tracking-[0.16em] text-muted">
-          The call
-        </p>
-        <p className="mt-3.5 text-[18px] text-fg">
-          90 minutes, 1:1, with the team that built and runs Gumclaw.
-        </p>
-        <ul className="mt-4 list-disc space-y-2 pl-5 text-muted-2 marker:text-[#ec4899]">
-          <li>
-            A teardown of where an agent can take work off your team first.
-          </li>
-          <li>
-            The architecture and guardrails we actually run in production.
-          </li>
-          <li>The org and trust changes that made it stick.</li>
-          <li>A prioritized 90-day automation plan for your company.</li>
-        </ul>
-        <p className="mt-[18px] text-[14px] text-muted">
-          For founders and operators of 5–100 person internet businesses who
-          want to grow without rebuilding a conventional team. $10,000 — less
-          than one month of the accountant time the agent replaced.
-        </p>
-        <p className="mt-4 rounded-[10px] border border-[#fbcfe8] bg-[#fdf2f8] px-4 py-3.5 text-[14px] text-[#9d174d]">
-          <strong className="text-[#9d174d]">Credit applies:</strong> if you
-          decide to have us help you build it afterward, the full $10,000 is
-          credited toward that engagement — so the call counts toward the work,
-          not on top of it.
-        </p>
-        <div className="mt-[22px]">
-          <BookCTA placement="offer" />
-        </div>
-      </section>
-
-      <p className="mt-14 scroll-mt-6 text-[13px] uppercase tracking-[0.18em] text-muted">
+      <p className="mt-10 scroll-mt-6 text-[13px] uppercase tracking-[0.18em] text-muted">
         Other ways to work with us
       </p>
 


### PR DESCRIPTION
Removes the dedicated **The call** offer section from the homepage. Booking already lives in the teardown rung via the subtle in-rung **Book a call →** pill (BookCTA, checkout + A/B tracking intact), and the full offer detail can live on the Gumroad product page itself.

Drops the whole `<section>` (heading, 90-min bullets, $10k pricing line, credit-applies note, and the offer-placement BookCTA). The intro paragraph above and the "Other ways to work with us" ladder below are unchanged.

- Build: clean
- Lockfile: restored (page-only diff)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/antiwork/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783542724&installation_id=134400930&pr_number=137&repository=antiwork%2Fantiwork&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fantiwork%2Fpull%2F137&signature=9a773555bbfbd28fd3ca7b00aa2d80d7d9720bc525918bd109e20e4d45bd60cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage-only copy/layout change; checkout and A/B-tracked booking remain on the rung CTA.
> 
> **Overview**
> Removes the standalone **The call** card from the homepage so the paid teardown offer isn’t duplicated above the pricing ladder.
> 
> The deleted block had the 90-minute 1:1 pitch, bullet list, $10k positioning, credit-applies callout, and a `BookCTA` with `placement="offer"`. The narrative paragraph before it and the **Other ways to work with us** rungs are unchanged; booking stays on the highlighted **The teardown call** rung via `BookCTA` with `placement="rung"`.
> 
> Spacing is tightened so **Other ways to work with us** follows the intro copy with `mt-10` instead of the extra gap left by the removed section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8caa5260a39458d7ba90f8815fd6a0facfee6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->