### PR TITLE
Homepage: add 'How we do it' execution model to consultancy block

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -515,6 +515,72 @@ export default function Home() {
         it from us.
       </p>
 
+      <p className="mt-12 scroll-mt-6 text-[13px] uppercase tracking-[0.18em] text-muted">
+        How we do it
+      </p>
+
+      <p className="mt-4 text-muted-2">
+        We&apos;re not a deck of advice. We point the same kind of agents that
+        run Gumroad at your company — hundreds of them, reading everything about
+        your business and the way you actually work. The agents do the work.
+        Your people move to the judgment calls.
+      </p>
+
+      <div className="mt-6 flex flex-col gap-3">
+        {/* Step 1 — agents analyze */}
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-[12px] border border-card-border bg-[color:var(--card)] bg-card px-5 py-4 shadow-card-sm">
+          <div className="flex-[1_1_260px]">
+            <p className="m-0 text-[15px] font-bold text-fg">
+              Hundreds of agents read your business
+            </p>
+            <p className="mt-1 text-[13px] text-muted">
+              They go through your codebase, your support history, your books,
+              and the way your team actually operates — every workflow, every
+              handoff, every recurring decision. Not a sample. All of it.
+            </p>
+          </div>
+          <p className="m-0 whitespace-nowrap text-[15px] font-bold text-[#ec4899]">
+            Analyze
+          </p>
+        </div>
+
+        {/* Step 2 — agents are primary */}
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-[12px] border border-card-border bg-[color:var(--card)] bg-card px-5 py-4 shadow-card-sm">
+          <div className="flex-[1_1_260px]">
+            <p className="m-0 text-[15px] font-bold text-fg">
+              The agents do the work
+            </p>
+            <p className="mt-1 text-[13px] text-muted">
+              They&apos;re the primary operators, not copilots waiting for a
+              prompt. They draft the code, answer the tickets, reconcile the
+              books, catch the fraud, and run the loop end to end — the same way
+              they run ours.
+            </p>
+          </div>
+          <p className="m-0 whitespace-nowrap text-[15px] font-bold text-[#ec4899]">
+            Execute
+          </p>
+        </div>
+
+        {/* Step 3 — humans in the loop */}
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-[12px] border border-card-border bg-[color:var(--card)] bg-card px-5 py-4 shadow-card-sm">
+          <div className="flex-[1_1_260px]">
+            <p className="m-0 text-[15px] font-bold text-fg">
+              Humans stay in the loop
+            </p>
+            <p className="mt-1 text-[13px] text-muted">
+              Your people set the guardrails, approve the irreversible calls,
+              and handle the edge cases the agents escalate. Fewer of them, each
+              with far more leverage — judgment on top, agents underneath doing
+              the volume.
+            </p>
+          </div>
+          <p className="m-0 whitespace-nowrap text-[15px] font-bold text-fg">
+            Decide
+          </p>
+        </div>
+      </div>
+
       <p className="mt-10 scroll-mt-6 text-[13px] uppercase tracking-[0.18em] text-muted">
         Other ways to work with us
       </p>


### PR DESCRIPTION
## What

Adds a **"How we do it"** section to the consultancy block on the antiwork.com homepage (`app/page.tsx`), right after "We'll show you how we did it…" and above the value ladder.

Three flat cards, same aesthetic as the existing ladder rungs, spelling out the execution model:

- **Hundreds of agents read your business** → *Analyze* — codebase, support history, books, and how the team actually operates; all of it, not a sample.
- **The agents do the work** → *Execute* — agents are the primary operators (not copilots): draft code, answer tickets, reconcile books, catch fraud, run the loop end to end.
- **Humans stay in the loop** → *Decide* — people set guardrails, approve irreversible calls, handle escalated edge cases; fewer of them, each with far more leverage.

## Why

The page sold the *outcome* of the consultancy but not the *method*. Sahil wants it explicit that this is an AI-native consultancy: **hundreds of agents analyzing everything about your business and the way you work, with humans in the loop but agents as the primary operators.** This section makes that the throughline.

## Notes

- Present-tense only (no "coming soon" phrasing), consistent with the rest of the page.
- No fabricated metrics — "hundreds of agents" describes the method, not a stat claim; no numbers in prose stat-boxes.
- Reuses the existing card/Tailwind patterns and brand pink `#ec4899`; diff is `app/page.tsx` only.
- Local `npm run build` green; verified by rendering the branch locally and screenshotting (preview is SSO-walled).

Opening as a **draft** for the Vercel preview — nothing ships until you approve.

Co-authored-by: Sahil Lavingia <sahil.lavingia@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/antiwork/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783955522&installation_id=134400930&pr_number=139&repository=antiwork%2Fantiwork&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fantiwork%2Fpull%2F139&signature=a2b837b37b47bfcce500fb3fe309e787110c3dfdbe86a2567ce93759460136b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->